### PR TITLE
Prevent special tags sent through Prox from working

### DIFF
--- a/src/blocks.js
+++ b/src/blocks.js
@@ -1,3 +1,5 @@
+import { removeSpecialTags } from './utils'
+
 export const SubmissionLayout = ({ id, isSensitive, postChannel, postNumber, status, text, user }) => {
     const displayName = `<@${user}>` || 'You’ve'
     return [
@@ -16,7 +18,7 @@ export const SubmissionLayout = ({ id, isSensitive, postChannel, postNumber, sta
             type: 'section',
             text: {
                 type: 'mrkdwn',
-                text: `>>> ${text}`
+                text: `>>> ${removeSpecialTags(text)}`
             }
         },
         ...status === 'waiting'

--- a/src/commands/lockdown.js
+++ b/src/commands/lockdown.js
@@ -1,5 +1,5 @@
 import Post from '../models/post'
-import { getParentMessageId, getPreview, isUserInChannel, sendMessage } from '../utils'
+import { getParentMessageId, getPreview, isUserInChannel, removeSpecialTags, sendMessage } from '../utils'
 
 // /prox lockdown <post number>
 export default async (bot, message, args) => {
@@ -32,7 +32,7 @@ export default async (bot, message, args) => {
     const updatedMessage = {
         id: post.postMessageId,
         conversation: { id: process.env.SLACK_POST_CHANNEL_ID },
-        text: `${post.lockedDownAt ? ':lock: ' : ''}*#${post.postNumber}:* ${post.body}`
+        text: `${post.lockedDownAt ? ':lock: ' : ''}*#${post.postNumber}:* ${removeSpecialTags(post.body)}`
     }
     await bot.updateMessage(updatedMessage)
 
@@ -50,5 +50,5 @@ export default async (bot, message, args) => {
     await bot.replyEphemeral(message, 'Lockdown status updated.')
 
     // Log status change
-    await sendMessage(bot, process.env.SLACK_STREAM_CHANNEL_ID, `_<@${message.user}> ${post.lockedDownAt ? 'locked' : 'unlocked'} *#${post.postNumber}*:_\n>>> ${getPreview(50, post.body)}`)
+    await sendMessage(bot, process.env.SLACK_STREAM_CHANNEL_ID, `_<@${message.user}> ${post.lockedDownAt ? 'locked' : 'unlocked'} *#${post.postNumber}*:_\n>>> ${getPreview(50, removeSpecialTags(post.body))}`)
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -96,3 +96,8 @@ export const getIcon = hash => {
     const { animal } = getPseudonym(hash)
     return icons[animal]
 }
+
+// Inserts zero-width non-joiner to prevent special tags like "@everyone" and "<!channel|channel>" from working
+export const removeSpecialTags = str => str
+    .replace(/@(channel|everyone|here)/ig, '@‌$1')
+    .replace(/\<\!(channel|everyone|here)\|(.*?)\>/ig, '<‌!$1|$2>')


### PR DESCRIPTION
This stops special tags like `@everyone` and `<!everyone|everyone>` that are sent through Prox from actually working.