### PR TITLE
Use random pseudonyms

### DIFF
--- a/src/features/post_reply.js
+++ b/src/features/post_reply.js
@@ -32,11 +32,10 @@ const findOrCreatePseudonym = async (post, user) => {
 const sendReplyToPost = async (client, say, user, post, message) => {
     const pseudonym = await findOrCreatePseudonym(post, user)
     const displayName = pseudonym.name + (pseudonym.userIdHash === post.authorIdHash ? ' (OP)' : '')
-    const icon = getIcon(pseudonym.noun)
     await sendMessage(client, config.postChannelId, {
         text: message,
         thread_ts: post.postMessageId,
-        icon_emoji: icon ? `:${icon}:` : null,
+        icon_emoji: getIcon(pseudonym.noun),
         username: displayName
     })
 

--- a/src/models/pseudonym.js
+++ b/src/models/pseudonym.js
@@ -1,4 +1,5 @@
 import mongoose from 'mongoose'
+import { capitalize } from '../utils'
 
 const PseudonymSchema = new mongoose.Schema({
     postId: {
@@ -11,10 +12,18 @@ const PseudonymSchema = new mongoose.Schema({
         required: true,
         immutable: true
     },
-    name: {
+    adjective: {
+        type: String,
+        required: true
+    },
+    noun: {
         type: String,
         required: true
     }
+})
+
+PseudonymSchema.virtual('name').get(function () {
+    return `${capitalize(this.adjective)} ${capitalize(this.noun)}`
 })
 
 export default mongoose.model('Pseudonym', PseudonymSchema)

--- a/src/models/pseudonym.js
+++ b/src/models/pseudonym.js
@@ -1,0 +1,20 @@
+import mongoose from 'mongoose'
+
+const PseudonymSchema = new mongoose.Schema({
+    postId: {
+        type: mongoose.Schema.Types.ObjectId,
+        required: true,
+        immutable: true
+    },
+    userIdHash: {
+        type: String,
+        required: true,
+        immutable: true
+    },
+    name: {
+        type: String,
+        required: true
+    }
+})
+
+export default mongoose.model('Pseudonym', PseudonymSchema)

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -11,7 +11,7 @@ export const generatePseudonymSet = () => ({
     noun: pickRandom(animals)
 })
 
-export const getIcon = noun => icons[noun]
+export const getIcon = noun => icons[noun] ? `:${icons[noun]}:` : null
 
 export const getIdFromUrl = inputUrl => {
     const url = new URL(inputUrl)

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -6,10 +6,12 @@ import icons from '../data/icons.json'
 
 export const capitalize = str => str.charAt(0).toUpperCase() + str.slice(1)
 
-export const getIcon = hash => {
-    const { animal } = getPseudonym(hash)
-    return icons[animal]
-}
+export const generatePseudonymSet = () => ({
+    adjective: pickRandom(adjectives),
+    noun: pickRandom(animals)
+})
+
+export const getIcon = noun => icons[noun]
 
 export const getIdFromUrl = inputUrl => {
     const url = new URL(inputUrl)
@@ -27,21 +29,13 @@ export const getIdFromUrl = inputUrl => {
     return formattedId
 }
 
-export const getPseudonym = hash => ({
-    adjective: adjectives[parseInt(hash.slice(0, 32), 16) % adjectives.length],
-    animal: animals[parseInt(hash.slice(32, hash.length), 16) % animals.length]
-})
-
 export const hash = (value, salt) => crypto.createHash('sha256')
     .update(value)
     .update(salt).digest('hex').toString()
+
+export const pickRandom = arr => arr[Math.floor(Math.random() * arr.length)]
 
 // Inserts zero-width non-joiner to prevent special tags like "@everyone" and "<!channel|channel>" from working
 export const removeSpecialTags = str => str
     .replace(/@(channel|everyone|here)/ig, '@\u200c$1')
     .replace(/\<\!(channel|everyone|here)\|(.*?)\>/ig, '<\u200c!$1|$2>')
-
-export const toPrettyPseudonym = hash => {
-    const { adjective, animal } = getPseudonym(hash)
-    return capitalize(adjective) + ' ' + capitalize(animal)
-}


### PR DESCRIPTION
Use randomly-generated pseudonyms that are stored in the DB instead of calculating one from the user's hash. Closes #31.